### PR TITLE
[FIX] Add missing PasswordResetNotification class

### DIFF
--- a/app/laravel/app/Notifications/PasswordResetNotification.php
+++ b/app/laravel/app/Notifications/PasswordResetNotification.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PasswordResetNotification extends Notification
+{
+    /**
+     * The password reset token.
+     *
+     * @var string
+     */
+    public $token;
+
+    /**
+     * The callback that should be used to create the reset password URL.
+     *
+     * @var (\Closure(mixed, string): string)|null
+     */
+    public static $createUrlCallback;
+
+    /**
+     * The callback that should be used to build the mail message.
+     *
+     * @var (\Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage)|null
+     */
+    public static $toMailCallback;
+
+    /**
+     * Create a notification instance.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array<int, string>|string
+     */
+    public function via($notifiable): array|string
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        if (static::$toMailCallback) {
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+        }
+
+        return $this->buildMailMessage($this->resetUrl($notifiable));
+    }
+
+    /**
+     * Get the reset password notification mail message for the given URL.
+     *
+     * @param  string  $url
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    protected function buildMailMessage($url)
+    {
+        return (new MailMessage)
+            ->subject(__('passwords.subject'))
+            ->line(__('passwords.header'))
+            ->action(__('passwords.button'), $url)
+            ->line(__('passwords.description', ['count' => config('auth.passwords.' . config('auth.defaults.passwords') . '.expire')]))
+            ->line(__('passwords.supplement'));
+    }
+
+    /**
+     * Get the reset URL for the given notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return string
+     */
+    protected function resetUrl($notifiable)
+    {
+        if (static::$createUrlCallback) {
+            return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
+        }
+
+        return url(route('password.reset', [
+            'token' => $this->token,
+            'email' => $notifiable->getEmailForPasswordReset(),
+        ], false));
+    }
+
+    /**
+     * Set a callback that should be used when creating the reset password button URL.
+     *
+     * @param  \Closure(mixed, string): string  $callback
+     * @return void
+     */
+    public static function createUrlUsing($callback)
+    {
+        static::$createUrlCallback = $callback;
+    }
+
+    /**
+     * Set a callback that should be used when building the notification mail message.
+     *
+     * @param  \Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage  $callback
+     * @return void
+     */
+    public static function toMailUsing($callback)
+    {
+        static::$toMailCallback = $callback;
+    }
+}


### PR DESCRIPTION
## Summary
Fix missing PasswordResetNotification class that was causing test failures

## Problem
- UserTest::test_sends_password_reset_notification was failing
- Class "App\Notifications\PasswordResetNotification" not found

## Solution
- Added PasswordResetNotification from PinkieIt commit fad82e6
- Missing from Phase 1 migration

## Test Results
- **Before**: 422/423 passing (1 failure)
- **After**: 423/423 passing (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)